### PR TITLE
Minor revisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,43 @@
 
 # Constraints.jl
 
-A  back-end package for JuliaConstraints front packages, such as `LocalSearchSolvers.jl`.
+A back-end package for JuliaConstraints front packages, such as `LocalSearchSolvers.jl`.
 
 It provides the following features:
-- A dictionary to store usual constraint: `usual_constraint`, which contains the following entries
-  - `:all_different`
-  - `:dist_different`
-  - `:eq`, `:all_equal`, `:all_equal_param`
-  - `:ordered`
-  - `:always_true` (mainly for testing default `Constraint()` constructor)
+- A dictionary to store usual constraint: `usual_constraint`, which contains the following entries (in alphabetical order):
+  - :`all_different`
+  - :`all_equal`
+  - :`at_least`
+  - :`at_most`
+  - :`cardinality`
+  - :`cardinality_closed`
+  - :`cardinality_open`
+  - :`channel`
+  - :`circuit`
+  - :`conflicts`
+  - :`count`
+  - :`cumulative`
+  - :`decreasing`
+  - :`dist_different`
+  - :`element`
+  - :`exactly`
+  - :`extension`
+  - :`increasing`
+  - :`instantiation`
+  - :`maximum`
+  - :`mdd`
+  - :`minimum`
+  - :`no_overlap`
+  - :`no_overlap_no_zero`
+  - :`no_overlap_with_zero`
+  - :`nvalues`
+  - :`ordered`
+  - :`regular`
+  - :`strictly_decreasing`
+  - :`strictly_increasing`
+  - :`sum`
+  - :`supports`
+
 - For each constraint `c`, the following properties
   - arguments length
   - concept (predicate the variables compliance with `c`)

--- a/src/constraints/all_different.jl
+++ b/src/constraints/all_different.jl
@@ -1,7 +1,7 @@
 #!SECTION - all_different
 
 const description_all_different = """
-    Global constraint ensuring that all the values of `x` are all different.
+Global constraint ensuring that all the values of `x` are all different.
 """
 
 """

--- a/src/constraints/all_equal.jl
+++ b/src/constraints/all_equal.jl
@@ -1,7 +1,7 @@
 #!SECTION - all_equal
 
 const description_all_equal = """
-    Global constraint ensuring that all the values of `x` are all equal.
+Global constraint ensuring that all the values of `x` are all equal.
 """
 
 concept_all_equal(x, val) = all(y -> y == val, x)

--- a/src/constraints/channel.jl
+++ b/src/constraints/channel.jl
@@ -1,4 +1,4 @@
-const description = """
+const description_channel = """
 The channel constraint establishes a bijective correspondence between two sets of variables. This means that each value in the first set of variables corresponds to a unique value in the second set, and vice versa.
 """
 
@@ -11,7 +11,7 @@ Return `true` if the channel constraint is satisfied, `false` otherwise. The cha
 - `list::Union{AbstractVector, Tuple}`: list of values to check.
 
 ## Variants
-- `:channel`: $description
+- `:channel`: $description_channel
 ```julia
 concept(:channel, x; dim=1, id=nothing)
 concept(:channel)(x; dim=1, id=nothing)

--- a/src/constraints/mdd.jl
+++ b/src/constraints/mdd.jl
@@ -1,9 +1,8 @@
 #!SECTION - Multi-valued Decision Diagram
 
 const description_mdd = """
-    Multi-valued Decision Diagram (MDD) constraint.
-
-    The MDD constraint is a constraint that can be used to model a wide range of problems. It is a directed graph where each node is labeled with a value and each edge is labeled with a value. The constraint is satisfied if there is a path from the first node to the last node such that the sequence of edge labels is a valid sequence of the value labels.
+Multi-valued Decision Diagram (MDD) constraint.
+The MDD constraint is a constraint that can be used to model a wide range of problems. It is a directed graph where each node is labeled with a value and each edge is labeled with a value. The constraint is satisfied if there is a path from the first node to the last node such that the sequence of edge labels is a valid sequence of the value labels.
 """
 
 """

--- a/src/constraints/ordered.jl
+++ b/src/constraints/ordered.jl
@@ -10,7 +10,7 @@ const description_decreasing = """
 Global constraint ensuring that all the values of `x` are in a decreasing order.
 """
 
-const description_sctrictly_increasing = """
+const description_strictly_increasing = """
 Global constraint ensuring that all the values of `x` are in a strictly increasing order.
 """
 
@@ -44,7 +44,7 @@ concept(:increasing)(x; op=≤, pair_vars=nothing)
 concept(:decreasing, x; op=≥, pair_vars=nothing)
 concept(:decreasing)(x; op=≥, pair_vars=nothing)
 ```
-- `:strictly_increasing`: $description_sctrictly_increasing
+- `:strictly_increasing`: $description_strictly_increasing
 ```julia
 concept(:strictly_increasing, x; op=<, pair_vars=nothing)
 concept(:strictly_increasing)(x; op=<, pair_vars=nothing)

--- a/src/constraints/ordered.jl
+++ b/src/constraints/ordered.jl
@@ -1,21 +1,21 @@
 const description_ordered = """
-    Global constraint ensuring that all the values of `x` are in an increasing order.
+Global constraint ensuring that all the values of `x` are in an increasing order.
 """
 
 const description_increasing = """
-    Global constraint ensuring that all the values of `x` are in an increasing order.
+Global constraint ensuring that all the values of `x` are in an increasing order.
 """
 
 const description_decreasing = """
-    Global constraint ensuring that all the values of `x` are in a decreasing order.
+Global constraint ensuring that all the values of `x` are in a decreasing order.
 """
 
 const description_sctrictly_increasing = """
-    Global constraint ensuring that all the values of `x` are in a strictly increasing order.
+Global constraint ensuring that all the values of `x` are in a strictly increasing order.
 """
 
 const description_strictly_decreasing = """
-    Global constraint ensuring that all the values of `x` are in a strictly decreasing order.
+Global constraint ensuring that all the values of `x` are in a strictly decreasing order.
 """
 
 """

--- a/src/constraints/regular.jl
+++ b/src/constraints/regular.jl
@@ -1,5 +1,5 @@
 const description_regular = """
-    Ensures that a sequence `x` (interpreted as a word) is accepted by the regular language represented by a given automaton. This constraint verifies the compliance of `x` with the language rules encoded within the `automaton` parameter, which must be an instance of `<:AbstractAutomaton`.
+Ensures that a sequence `x` (interpreted as a word) is accepted by the regular language represented by a given automaton. This constraint verifies the compliance of `x` with the language rules encoded within the `automaton` parameter, which must be an instance of `<:AbstractAutomaton`.
 """
 
 """

--- a/src/usual_constraints.jl
+++ b/src/usual_constraints.jl
@@ -9,7 +9,7 @@ Adding a new constraint is as simple as defining a new function with the same na
 @usual concept_all_different(x; vals=nothing) = xcsp_all_different(list=x, except=vals)
 ```
 """
-const USUAL_CONSTRAINTS = Dict{Symbol, Constraint}(:always_true => Constraint())
+const USUAL_CONSTRAINTS = Dict{Symbol, Constraint}()
 
 """
     describe(constraints::Dict{Symbol,Constraint}=USUAL_CONSTRAINTS; width=150)
@@ -40,6 +40,8 @@ function describe(constraints::Dict{Symbol, Constraint} = USUAL_CONSTRAINTS; wid
         alignment = :l
     )
 end
+
+describe(s::Symbol) = USUAL_CONSTRAINTS[s].description
 
 """
     extract_parameters(s::Symbol, constraints_dict=USUAL_CONSTRAINTS; parameters=ConstraintCommons.USUAL_CONSTRAINT_PARAMETERS)


### PR DESCRIPTION
- Update `README.md` with the full set of keys in the `USUAL_CONSTRAINTS` dictionary
- Fix typos resulting in incorrect displaying of constraint descriptions with `describe()`
- Add an implementation of `describe()` for displaying description of individual constraints
- Removes `:always_true` from `USUAL_CONSTRAINTS`