### PR TITLE
Update constraint descriptions

### DIFF
--- a/src/constraints/all_different.jl
+++ b/src/constraints/all_different.jl
@@ -1,7 +1,7 @@
 #!SECTION - all_different
 
 const description_all_different = """
-Global constraint ensuring that all the values of `x` are all different.
+Global constraint ensuring that the values in `x` are all different.
 """
 
 """

--- a/src/constraints/all_equal.jl
+++ b/src/constraints/all_equal.jl
@@ -1,7 +1,7 @@
 #!SECTION - all_equal
 
 const description_all_equal = """
-Global constraint ensuring that all the values of `x` are all equal.
+Global constraint ensuring that the values in `x` are all equal.
 """
 
 concept_all_equal(x, val) = all(y -> y == val, x)

--- a/src/constraints/cardinality.jl
+++ b/src/constraints/cardinality.jl
@@ -1,14 +1,13 @@
 # cardinality (or global_cardinality or gcc)
 
 const description_cardinality = """
-The cardinality constraint, also known as the global cardinality constraint (GCC), is a constraint in constraint programming that restricts the number of times a value can appear in a set of variables.
+Global constraint that restricts the number of times specific values in a list `values` can appear in `x`.
 """
 const description_cardinality_closed = """
-The closed cardinality constraint, also known as the global cardinality constraint (GCC), is a constraint in constraint programming that restricts the number of times a value can appear in a set of variables. It is closed, meaning that all values in the domain of the variables must be considered.
+Global constraint that restricts the number of times in a list `values` can appear in `x`. It is closed, meaning that the variables in `x` cannot have values outside the ones in `list`.
 """
-
 const description_cardinality_open = """
-The open cardinality constraint, also known as the global cardinality constraint (GCC), is a constraint in constraint programming that restricts the number of times a value can appear in a set of variables. It is open, meaning that only the values in the list of values must be considered.
+Global constraint that restricts the number of times in a list `values` can appear in `x`. It is open, meaning that the variables in `x` can have values outside the ones in `list`.
 """
 
 """

--- a/src/constraints/channel.jl
+++ b/src/constraints/channel.jl
@@ -1,11 +1,11 @@
 const description_channel = """
-The channel constraint establishes a bijective correspondence between two sets of variables. This means that each value in the first set of variables corresponds to a unique value in the second set, and vice versa.
+Ensures that if the i-th element of `x` is assigned the value j, then the j-th element of `x` must be assigned the value i.
 """
 
 """
     xcsp_channel(; list)
 
-Return `true` if the channel constraint is satisfied, `false` otherwise. The channel constraint establishes a bijective correspondence between two sets of variables. This means that each value in the first set of variables corresponds to a unique value in the second set, and vice versa.
+Return `true` if the channel constraint is satisfied, `false` otherwise. The channel constraint ensures that if the i-th element of `list` is assigned the value j, then the j-th element of `list` must be assigned the value i.
 
 ## Arguments
 - `list::Union{AbstractVector, Tuple}`: list of values to check.

--- a/src/constraints/circuit.jl
+++ b/src/constraints/circuit.jl
@@ -1,11 +1,11 @@
 const description_circuit = """
-The circuit constraint is a global constraint used in constraint programming, often in routing problems. It ensures that the values of a list of variables form a circuit, i.e., a sequence where each value is the index of the next value in the sequence, and the sequence eventually loops back to the start.
+Global constraint ensuring that the values of `x` form a circuit, i.e., a sequence where each value is the index of the next value in the sequence, and the sequence eventually loops back to the start. Often used for routing problems.
 """
 
 """
     xcsp_circuit(; list, size)
 
-Return `true` if the circuit constraint is satisfied, `false` otherwise. The circuit constraint is a global constraint used in constraint programming, often in routing problems. It ensures that the values of a list of variables form a circuit, i.e., a sequence where each value is the index of the next value in the sequence, and the sequence eventually loops back to the start.
+Return `true` if the circuit constraint is satisfied, `false` otherwise. The circuit constraint is a global constraint ensuring that the values of a list of variables form a circuit, i.e., a sequence where each value is the index of the next value in the sequence, and the sequence eventually loops back to the start.
 
 ## Arguments
 - `list::AbstractVector`: list of values to check.

--- a/src/constraints/circuit.jl
+++ b/src/constraints/circuit.jl
@@ -5,7 +5,7 @@ Global constraint ensuring that the values of `x` form a circuit, i.e., a sequen
 """
     xcsp_circuit(; list, size)
 
-Return `true` if the circuit constraint is satisfied, `false` otherwise. The circuit constraint is a global constraint ensuring that the values of a list of variables form a circuit, i.e., a sequence where each value is the index of the next value in the sequence, and the sequence eventually loops back to the start.
+Return `true` if the circuit constraint is satisfied, `false` otherwise. The circuit constraint is a global constraint ensuring that the values of `x` form a circuit, i.e., a sequence where each value is the index of the next value in the sequence, and the sequence eventually loops back to the start.
 
 ## Arguments
 - `list::AbstractVector`: list of values to check.

--- a/src/constraints/cumulative.jl
+++ b/src/constraints/cumulative.jl
@@ -1,11 +1,11 @@
 const description_cumulative = """
-The cumulative constraint is a global constraint used in constraint programming that is often used in scheduling problems. It ensures that for any point in time, the sum of the "heights" of tasks that are ongoing at that time does not exceed a certain limit.
+Global constraint ensuring that for any point in time, the sum of the "heights" of tasks that are ongoing at that time does not exceed a certain limit. Often used in scheduling problems
 """
 
 """
     xcsp_cumulative(; origins, lengths, heights, condition)
 
-Return `true` if the cumulative constraint is satisfied, `false` otherwise. The cumulative constraint is a global constraint used in constraint programming that is often used in scheduling problems. It ensures that for any point in time, the sum of the "heights" of tasks that are ongoing at that time does not exceed a certain limit.
+Return `true` if the cumulative constraint is satisfied, `false` otherwise. The cumulative constraint is a global constraint ensuring that for any point in time, the sum of the "heights" of tasks that are ongoing at that time does not exceed a certain limit.
 
 ## Arguments
 - `origins::AbstractVector`: list of origins of the tasks.

--- a/src/constraints/cumulative.jl
+++ b/src/constraints/cumulative.jl
@@ -1,11 +1,11 @@
 const description_cumulative = """
-Global constraint ensuring that for any point in time, the sum of the "heights" of tasks that are ongoing at that time does not exceed a certain limit. Often used in scheduling problems
+Global constraint operating on a set of tasks, defined by `origin` (starting times), `length`, and `height`. This constraint ensures that, at each point in time, the sum of the `height` of tasks that overlap that point, respects a numerical condition.
 """
 
 """
     xcsp_cumulative(; origins, lengths, heights, condition)
 
-Return `true` if the cumulative constraint is satisfied, `false` otherwise. The cumulative constraint is a global constraint ensuring that for any point in time, the sum of the "heights" of tasks that are ongoing at that time does not exceed a certain limit.
+Return `true` if the cumulative constraint is satisfied, `false` otherwise. The cumulative constraint is a global constraint operating on a set of tasks, defined by `origin` (starting times), `length`, and `height`. This constraint ensures that, at each point in time, the sum of the `height` of tasks that overlap that point, respects a numerical condition.
 
 ## Arguments
 - `origins::AbstractVector`: list of origins of the tasks.

--- a/src/constraints/element.jl
+++ b/src/constraints/element.jl
@@ -1,11 +1,11 @@
 const description_element = """
-The element constraint is a global constraint used in constraint programming that specifies that the value of a variable should be equal to the value of another variable indexed by a third variable.
+Global constraint specifying that a variable in `x` indexed by `id` should be equal to a `value`.
 """
 
 """
     xcsp_element(; list, index, condition)
 
-Return `true` if the element constraint is satisfied, `false` otherwise. The element constraint is a global constraint used in constraint programming that specifies that the value of a variable should be equal to the value of another variable indexed by a third variable.
+Return `true` if the element constraint is satisfied, `false` otherwise. The element constraint is a global constraint specifying that a variable in `x` indexed by `id` should be equal to a `value`.
 
 ## Arguments
 - `list::Union{AbstractVector, Tuple}`: list of values to check.

--- a/src/constraints/extension.jl
+++ b/src/constraints/extension.jl
@@ -3,15 +3,15 @@
 # TODO - Better input for conflicts and supports (cf XCSP3-core)
 
 const description_extension = """
-Global constraint enforcing that the tuple `x` matches a configuration within the supports set `pair_vars[1]` or does not match any configuration within the conflicts set `pair_vars[2]`. It embodies the logic: `x ∈ pair_vars[1] || x ∉ pair_vars[2]`, providing a comprehensive way to define valid (supported) and invalid (conflicted) tuples for constraint satisfaction problems. This constraint is versatile, allowing for the explicit delineation of both acceptable and unacceptable configurations.
+Global constraint enforcing that `x` matches a configuration within the supports set `pair_vars[1]` or does not match any configuration within the conflicts set `pair_vars[2]`. It embodies the logic: `x ∈ pair_vars[1] || x ∉ pair_vars[2]`, providing a comprehensive way to define valid (supported) and invalid (conflicted) configurations for constraint satisfaction problems.
 """
 
 const description_supports = """
-Global constraint ensuring that the tuple `x` matches a configuration listed within the support set `pair_vars`. This constraint is derived from the extension model, specifying that `x` must be one of the explicitly defined supported configurations: `x ∈ pair_vars`. It is utilized to directly declare the tuples that are valid and should be included in the solution space.
+Global constraint ensuring that `x` matches a configuration listed within the support set `pair_vars`. This constraint is derived from the extension model, specifying that `x` must be one of the explicitly defined supported configurations: `x ∈ pair_vars`. It is utilized to directly declare the configurations that are valid and should be included in the solution space.
 """
 
 const description_conflicts = """
-Global constraint ensuring that the tuple `x` does not match any configuration listed within the conflict set `pair_vars`. This constraint, originating from the extension model, stipulates that `x` must avoid all configurations defined as conflicts: `x ∉ pair_vars`. It is useful for specifying tuples that are explicitly forbidden and should be excluded from the solution space.
+Global constraint ensuring that `x` does not match any configuration listed within the conflict set `pair_vars`. This constraint, originating from the extension model, stipulates that `x` must avoid all configurations defined as conflicts: `x ∉ pair_vars`. It is useful for specifying configurations that are explicitly forbidden and should be excluded from the solution space.
 """
 
 xcsp_extension(list, ::Nothing, conflicts) = list ∉ conflicts

--- a/src/constraints/instantiation.jl
+++ b/src/constraints/instantiation.jl
@@ -1,11 +1,11 @@
 const description_instantiation = """
-The instantiation constraint is a global constraint used in constraint programming that ensures that a list of variables takes on a specific set of values in a specific order.
+Global constraint ensuring that `x` takes on a specific set of `values` in a specific order.
 """
 
 """
     xcsp_instantiation(; list, values)
 
-Return `true` if the instantiation constraint is satisfied, `false` otherwise. The instantiation constraint is a global constraint used in constraint programming that ensures that a list of variables takes on a specific set of values in a specific order.
+Return `true` if the instantiation constraint is satisfied, `false` otherwise. The instantiation constraint is a global constraint ensuring that `x` takes on a specific set of `values` in a specific order.
 
 ## Arguments
 - `list::AbstractVector`: list of values to check.

--- a/src/constraints/intention.jl
+++ b/src/constraints/intention.jl
@@ -3,7 +3,7 @@
 # TODO - Add a DSL for intension (cf XCSP3-core)
 
 const description_dist_different = """
-A constraint ensuring that the distances between marks on the ruler are unique. Specifically, it checks that the distance between `x[1]` and `x[2]`, and the distance between `x[3]` and `x[4]`, are different. This constraint is fundamental in ensuring the validity of a Golomb ruler, where no two pairs of marks should have the same distance between them.
+Given a 4-dimensional vector `x`, ensures that the absolute difference between `x[1]` and `x[2]`, and between `x[3]` and `x[4]`, are different. This constraint is fundamental in ensuring the validity of a Golomb ruler, where no two pairs of marks should have the same distance between them.
 """
 
 """

--- a/src/constraints/maximum.jl
+++ b/src/constraints/maximum.jl
@@ -1,11 +1,11 @@
 const description_maximum = """
-The maximum constraint is a global constraint used in constraint programming that specifies that a certain condition should hold for the maximum value in a list of variables.
+Global constraint ensuring that a certain numerical condition holds for the maximum value in `x`.
 """
 
 """
     xcsp_maximum(; list, condition)
 
-Return `true` if the maximum constraint is satisfied, `false` otherwise. The maximum constraint is a global constraint used in constraint programming that specifies that a certain condition should hold for the maximum value in a list of variables.
+Return `true` if the maximum constraint is satisfied, `false` otherwise. The maximum constraint is a global constraint specifying that a certain condition should hold for the maximum value in a list of variables.
 
 ## Arguments
 - `list::Union{AbstractVector, Tuple}`: list of values to check.

--- a/src/constraints/minimum.jl
+++ b/src/constraints/minimum.jl
@@ -1,5 +1,5 @@
 const description_minimum = """
-Global constraint specifying that a certain numerical condition should hold for the minimum value in `x`.
+Global constraint ensuring that a certain numerical condition holds for the minimum value in `x`.
 """
 
 """

--- a/src/constraints/minimum.jl
+++ b/src/constraints/minimum.jl
@@ -1,11 +1,11 @@
 const description_minimum = """
-The minimum constraint is a global constraint used in constraint programming that specifies that a certain condition should hold for the minimum value in a list of variables.
+Global constraint specifying that a certain numerical condition should hold for the minimum value in `x`.
 """
 
 """
     xcsp_minimum(; list, condition)
 
-Return `true` if the minimum constraint is satisfied, `false` otherwise. The minimum constraint is a global constraint used in constraint programming that specifies that a certain condition should hold for the minimum value in a list of variables.
+Return `true` if the minimum constraint is satisfied, `false` otherwise. The minimum constraint is a global constraint specifying that a certain condition should hold for the minimum value in a list of variables.
 
 ## Arguments
 - `list::Union{AbstractVector, Tuple}`: list of values to check.

--- a/src/constraints/n_values.jl
+++ b/src/constraints/n_values.jl
@@ -1,7 +1,8 @@
 #!SECTION - nValues
 
 const description_nvalues = """
-The nValues constraint specifies that the number of distinct values in the list of variables x is equal to a given value. The constraint is defined by the following expression: nValues(x, op, val) where x is a list of variables, op is a comparison operator, and val is an integer value.
+Ensures that the number of distinct values in `x` satisfies a given numerical condition. 
+The constraint is defined by the following expression: `nValues(x, op, val)` where `x` is a list of variables, `op` is a comparison operator, and `val` is an integer value.
 """
 
 """

--- a/src/constraints/no_overlap.jl
+++ b/src/constraints/no_overlap.jl
@@ -1,13 +1,13 @@
 const description_no_overlap = """
-The no_overlap constraint is a global constraint used in constraint programming, often in scheduling problems. It ensures that tasks do not overlap in time, i.e., for any two tasks, either the first task finishes before the second task starts, or the second task finishes before the first task starts.
+Global constraint operating on a set of tasks, defined by `origin` (starting times), and `length`. This constraint ensures that tasks do not overlap in time, i.e., for any two tasks, either the first task finishes before the second task starts, or the second task finishes before the first task starts. Often used in scheduling problems.
 """
 
 const description_no_overlap_no_zero = """
-The no_overlap constraint is a global constraint used in constraint programming, often in scheduling problems. It ensures that tasks do not overlap in time, i.e., for any two tasks, either the first task finishes before the second task starts, or the second task finishes before the first task starts. This variant ignores zero-length tasks.
+Global constraint operating on a set of tasks, defined by `origin` (starting times), and `length`. This constraint ensures that tasks do not overlap in time, i.e., for any two tasks, either the first task finishes before the second task starts, or the second task finishes before the first task starts. This variant ignores zero-length tasks. Often used in scheduling problems.
 """
 
 const description_no_overlap_with_zero = """
-The no_overlap constraint is a global constraint used in constraint programming, often in scheduling problems. It ensures that tasks do not overlap in time, i.e., for any two tasks, either the first task finishes before the second task starts, or the second task finishes before the first task starts. This variant includes zero-length tasks.
+Global constraint operating on a set of tasks, defined by `origin` (starting times), and `length`. This constraint ensures that tasks do not overlap in time, i.e., for any two tasks, either the first task finishes before the second task starts, or the second task finishes before the first task starts. This variant includes zero-length tasks. Often used in scheduling problems.
 """
 
 """

--- a/src/constraints/ordered.jl
+++ b/src/constraints/ordered.jl
@@ -1,5 +1,5 @@
 const description_ordered = """
-Global constraint ensuring that all the values of `x` are in an increasing order.
+Global constraint ensuring that all the values of `x` are in a total order defined by a comparison operator.
 """
 
 const description_increasing = """

--- a/src/constraints/sum.jl
+++ b/src/constraints/sum.jl
@@ -1,5 +1,5 @@
 const description_sum = """
-Global constraint ensuring that the sum of the variables in `x` satisfies a given condition.
+Global constraint ensuring that the sum of the variables in `x` satisfies a given numerical condition.
 """
 
 """


### PR DESCRIPTION
This PR adjusts the text descriptions for all the constraints.

Summary of the changes:
- We now consistently refer to `x` as the input list of variables.
- We explicitly refer to the keyword argument the constraint accepts, where appropriate.
- Boilerplate text was removed.

Suggestions?